### PR TITLE
Fixed unhandled exception when cancel is called on the CancellationToken

### DIFF
--- a/websocket-sharp.clone/WebSocket.cs
+++ b/websocket-sharp.clone/WebSocket.cs
@@ -200,7 +200,18 @@ namespace WebSocketSharp
             _onClose = onClose ?? (c => AsyncEx.Completed());
             _sslConfig = sslAuthConfiguration;
             _cancellationToken = cancellationToken;
-            _registration = _cancellationToken.Register(async () => await Close().ConfigureAwait(false));
+            _registration = _cancellationToken.Register(
+                async () =>
+                    {
+                        try
+                        {
+                            await Close().ConfigureAwait(false);
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            // ignore
+                        }
+                    });
             _base64Key = CreateBase64Key();
             _client = true;
             _secure = _uri.Scheme == "wss";


### PR DESCRIPTION
Hi, first of all great work!

Code to reproduce:
```
var cts = new CancellationTokenSource();
var websocket = new WebSocket("ws://1.2.3.4/dummy", cts.Token);

// After any moment in time
cts.Cancel(); // this causes an uncaught TaskCancelledException
```
Which led me to the async void lambda expression ;)