### PR TITLE
Fix unreleased semaphore

### DIFF
--- a/websocket-sharp.clone/WebSocketStreamReader.cs
+++ b/websocket-sharp.clone/WebSocketStreamReader.cs
@@ -43,12 +43,14 @@ namespace WebSocketSharp
 
             if (_isClosed)
             {
+                _waitHandle.Release();
                 return null;
             }
 
             header = await ReadHeader(cancellationToken).ConfigureAwait(false);
             if (header == null)
             {
+                _waitHandle.Release();
                 return null;
             }
 
@@ -59,6 +61,8 @@ namespace WebSocketSharp
             {
                 _isClosed = true;
             }
+                
+            _waitHandle.Release();
 
             return msg;
         }


### PR DESCRIPTION
A semaphore wasn't released after it was catched which entirely prevented the WebSocket from receiving messages.